### PR TITLE
Fix LSHSpec; blockID isn't 0-based index

### DIFF
--- a/src/test/scala-2.11/SparkER/BlockBuildingMethods/LSHSpec.scala
+++ b/src/test/scala-2.11/SparkER/BlockBuildingMethods/LSHSpec.scala
@@ -212,12 +212,16 @@ class LSHSpec extends WordSpec with Matchers with SharedSparkContext {
         )
         val actual = LSH.createBlocks(
           profiles = dataset1.union(dataset2),
-          numHashes = 128,
+          numHashes = 4,
           targetThreshold = 0.5,
           separatorIDs = Array(dataset1.map(_.id).max)
         ).collect
+
         val expected = Seq(
-          BlockClean(blockID = 0, profiles = Array(Set(0),Set(1)))
+          BlockClean(blockID = -2107927677, profiles = Array(Set(0),Set(1))),
+          BlockClean(blockID = 133683514, profiles = Array(Set(0),Set(1))),
+          BlockClean(blockID = 260160282, profiles = Array(Set(0),Set(1))),
+          BlockClean(blockID = 2082721775, profiles = Array(Set(0),Set(1)))
         )
         actual.map(_.blockID) should contain theSameElementsAs expected.map(_.blockID)
         actual.map(_.profiles) should contain theSameElementsAs expected.map(_.profiles)


### PR DESCRIPTION
Hi,
Sorry, I found that I made a wrong test case in LSHSpec.
LSHSpec now passes all of its test cases:
```
$ sbt "testOnly *.LSHSpec"
[info] welcome to sbt 1.5.4 (Debian Java 11.0.11)
[info] loading project definition from /home/itoyota/Programs/JedAI-Spark/project
[info] loading settings for project jedai-spark from build.sbt ...
[info] set current project to spark_er (in build file:/home/itoyota/Programs/JedAI-Spark/)
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.hadoop.security.authentication.util.KerberosUtil (file:/home/itoyota/.cache/coursier/v1/https/repo1.maven.org/maven2/org/apache/hadoop/hadoop-auth/2.8.3/hadoop-auth-2.8.3.jar) to method sun.security.krb5.Config.getInstance()
WARNING: Please consider reporting this to the maintainers of org.apache.hadoop.security.authentication.util.KerberosUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
21/07/05 00:48:38 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
21/07/05 00:48:38 WARN Utils: Your hostname, debian resolves to a loopback address: 127.0.1.1; using 192.168.10.12 instead (on interface enp9s0)
21/07/05 00:48:38 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
NUMERO DI RIGHE 10
NUMERO DI RIGHE 10
[info] LSHSpec:
[info] LSH.getHashes2
[info] - should return a hash which contains the specified number of bits
[info] - should return the same hash if given two strings are the same
[info] LSH.getNumBands
[info]   should return the number of bands
[info]   - when given threshold is 1.0
[info]   - when given threshold is 0.8
[info]   - when given threshold is 0.0
[info] LSH.getNumRows
[info] - should return the number of rows
[info] LSH.calcSimilarity
[info]   should return the similarity
[info]   - when sig1 and sig2 shares the totally same elements
[info]   should return NaN
[info]   - when neither sig1 nor sig2 has elements
[info] LSH.clusterSimilarAttributes
[info]   should put name and label into the same cluster (excepting bar)
[info]   - when their jaccard similarity is greater than threshold and LMI could capture them
[info]   should put name, label and bar into the same cluster
[info]   - when there are no similar attributes
[info] LSH.createBlocks
[info]   should create no blocks
[info]   - when given two profiles aren't similar (jaccard similarity(p0,p1) = 0.33 < threshold)
[info]   should create blocks
[info]   - when given two profiles are similar (jaccard similarity(p0,p1) = 1.0 > threshold)
[info] Run completed in 3 seconds, 128 milliseconds.
[info] Total number of tests run: 12
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 12, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 5 s, completed 2021/07/05 0:48:40

```

Cheers,